### PR TITLE
printList and showSearchResults: add streams

### DIFF
--- a/data/list.txt
+++ b/data/list.txt
@@ -1,0 +1,4 @@
+T | 0 | CS2100 Assignment
+E | 0 | CS2103t tutorial | today 12pm
+D | 0 | CS2103T quiz | tomorrow 4pm
+D | 1 | CS2103t level 9 | today

--- a/src/main/java/duke/TaskList.java
+++ b/src/main/java/duke/TaskList.java
@@ -3,6 +3,8 @@ package duke;
 import java.io.IOException;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import duke.Task.Category;
 
@@ -34,12 +36,16 @@ public class TaskList {
      * @return String of the current <code>TaskList</code> that has been formatted properly.
      */
     public String printList() {
-        String listString = "";
-        for (int i = 0; i < list.size(); i++) {
-            int index = i + 1;
-            listString = listString + index + "." + list.get(i).toString() + "\n";
-        }
-        return listString;
+
+        String listToString = IntStream
+            .range(0, list.size())
+            .mapToObj(index -> {
+                Task currTask = list.get(index);
+                return index + "." + currTask;
+            })
+            .collect(Collectors.joining("\n"));
+
+        return listToString;
     }
 
     /**

--- a/src/main/java/duke/Ui.java
+++ b/src/main/java/duke/Ui.java
@@ -2,6 +2,9 @@ package duke;
 
 import java.util.ArrayList;
 import java.util.Scanner;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * Represents the interface that interacts with the user, receiving commands from the user and
@@ -124,14 +127,18 @@ public class Ui {
      * @param resultsArray ArrayList of <code>Task</code> results from search.
      */
     public String showSearchResults(ArrayList<Task> resultsArray) {
+
         String result = FRIENDGREETING + "Here are the matching tasks in your list:\n";
-        int listSize = resultsArray.size();
-        for (int i = 0; i < listSize; i++) {
-            Task currTask = resultsArray.get(i);
-            int index = i + 1;
-            result = result + index + "." + currTask.toString() + "\n";
-        }
-        return result;
+
+        String content = IntStream
+            .range(0, resultsArray.size())
+            .mapToObj(index -> {
+                Task currTask = resultsArray.get(index);
+                return index + "." + currTask;
+            })
+            .collect(Collectors.joining("\n"));
+
+        return result + content;
     }
 
     /**


### PR DESCRIPTION
Current printList and showSearchResults are cumbersome and involve verbose for loops over the ArrayList of Tasks.

Using streams to map each index in the list to the correct String format makes for cleaner code and increases code quality.

Streams are also used to show understanding of new Java 8 features.

Let's
* Rewrite the existing printList and showSearchResults in the Storage and Ui classes respectively
* Test the implementation via GUI